### PR TITLE
sdk: add optional Subject and Abstract fields to SendEmailTemplateReq

### DIFF
--- a/tests/test_services/test_email.py
+++ b/tests/test_services/test_email.py
@@ -22,7 +22,7 @@ from uspeedo.services.email.client import EmailClient
 
 
 def _build_minimal_req():
-    """最小请求构造（不含 Subject/Abstract）"""
+    """Build minimal request (without Subject/Abstract)"""
     return {
         "TemplateId": "UETXXXXXXXXXXX",
         "SendEmail": "examples@examples.com",
@@ -36,7 +36,7 @@ def _build_minimal_req():
 
 
 def test_send_email_template_dumps_without_optional_fields():
-    """不传 Subject/Abstract 时 dumps 结果不包含这两个字段，兼容历史版本"""
+    """When Subject/Abstract are not passed, dumps result excludes these fields for backward compatibility"""
     req = SendEmailTemplateReq().dumps(_build_minimal_req())
     assert "TemplateId" in req
     assert "SendEmail" in req
@@ -46,13 +46,13 @@ def test_send_email_template_dumps_without_optional_fields():
 
 
 def test_send_email_template_dumps_with_optional_fields():
-    """传入 Subject/Abstract 时 dumps 结果正确包含"""
+    """When Subject/Abstract are passed, dumps result correctly includes them"""
     d = _build_minimal_req()
-    d["Subject"] = "自定义邮件主题"
-    d["Abstract"] = "邮件摘要内容"
+    d["Subject"] = "Custom email subject"
+    d["Abstract"] = "Email abstract content"
     req = SendEmailTemplateReq().dumps(d)
-    assert req["Subject"] == "自定义邮件主题"
-    assert req["Abstract"] == "邮件摘要内容"
+    assert req["Subject"] == "Custom email subject"
+    assert req["Abstract"] == "Email abstract content"
 
 
 @pytest.mark.skipif(
@@ -60,7 +60,7 @@ def test_send_email_template_dumps_with_optional_fields():
     reason="Skip: USpeedo_PUBLIC_KEY or USpeedo_PRIVATE_KEY not set",
 )
 def test_send_email_template_integration():
-    """真实 API 调用，需设置环境变量 USpeedo_PUBLIC_KEY、USpeedo_PRIVATE_KEY"""
+    """Real API call, requires USpeedo_PUBLIC_KEY and USpeedo_PRIVATE_KEY env vars"""
     config = {
         "public_key": os.getenv("USpeedo_PUBLIC_KEY"),
         "private_key": os.getenv("USpeedo_PRIVATE_KEY"),
@@ -68,8 +68,8 @@ def test_send_email_template_integration():
     client = EmailClient(config)
 
     req = _build_minimal_req()
-    req["Subject"] = "集成测试主题"
-    req["Abstract"] = "集成测试摘要"
+    req["Subject"] = "Integration test subject"
+    req["Abstract"] = "Integration test abstract"
 
     resp = client.send_email_template(req)
 

--- a/tests/test_services/test_email.py
+++ b/tests/test_services/test_email.py
@@ -1,0 +1,76 @@
+"""
+Copyright 2024 USpeedo Technology Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import os
+import pytest
+
+from uspeedo.services.email.apis.SendEmailTemplateReq import SendEmailTemplateReq
+from uspeedo.services.email.client import EmailClient
+
+
+def _build_minimal_req():
+    """最小请求构造（不含 Subject/Abstract）"""
+    return {
+        "TemplateId": "UETXXXXXXXXXXX",
+        "SendEmail": "examples@examples.com",
+        "EmailContent": [
+            {
+                "EmailAddress": "example@examples.com",
+                "TemplateVariableParams": ["variableName{##}variableValue"],
+            }
+        ],
+    }
+
+
+def test_send_email_template_dumps_without_optional_fields():
+    """不传 Subject/Abstract 时 dumps 结果不包含这两个字段，兼容历史版本"""
+    req = SendEmailTemplateReq().dumps(_build_minimal_req())
+    assert "TemplateId" in req
+    assert "SendEmail" in req
+    assert "EmailContent" in req
+    assert "Subject" not in req
+    assert "Abstract" not in req
+
+
+def test_send_email_template_dumps_with_optional_fields():
+    """传入 Subject/Abstract 时 dumps 结果正确包含"""
+    d = _build_minimal_req()
+    d["Subject"] = "自定义邮件主题"
+    d["Abstract"] = "邮件摘要内容"
+    req = SendEmailTemplateReq().dumps(d)
+    assert req["Subject"] == "自定义邮件主题"
+    assert req["Abstract"] == "邮件摘要内容"
+
+
+@pytest.mark.skipif(
+    not os.getenv("USpeedo_PUBLIC_KEY") or not os.getenv("USpeedo_PRIVATE_KEY"),
+    reason="Skip: USpeedo_PUBLIC_KEY or USpeedo_PRIVATE_KEY not set",
+)
+def test_send_email_template_integration():
+    """真实 API 调用，需设置环境变量 USpeedo_PUBLIC_KEY、USpeedo_PRIVATE_KEY"""
+    config = {
+        "public_key": os.getenv("USpeedo_PUBLIC_KEY"),
+        "private_key": os.getenv("USpeedo_PRIVATE_KEY"),
+    }
+    client = EmailClient(config)
+
+    req = _build_minimal_req()
+    req["Subject"] = "集成测试主题"
+    req["Abstract"] = "集成测试摘要"
+
+    resp = client.send_email_template(req)
+
+    assert resp is not None

--- a/uspeedo/services/email/apis/SendEmailTemplateReq.py
+++ b/uspeedo/services/email/apis/SendEmailTemplateReq.py
@@ -28,4 +28,6 @@ class SendEmailTemplateReq(schema.RequestSchema):
         "EmailContent": fields.List(TargetEmail(), required=True, dump_to="EmailContent", load_from="EmailContent"),
         "SendEmail": fields.Str(required=True, dump_to="SendEmail", load_from="SendEmail"),
         "TemplateId": fields.Str(required=True, dump_to="TemplateId", load_from="TemplateId"),
+        "Subject": fields.Str(required=False, dump_to="Subject", load_from="Subject"),
+        "Abstract": fields.Str(required=False, dump_to="Abstract", load_from="Abstract"),
     }


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->

FEATURES:

ENHANCEMENTS:

BUG FIXES:
